### PR TITLE
React: Add IconGroup component.

### DIFF
--- a/sassquatch-react/client/app/Components/Button.js
+++ b/sassquatch-react/client/app/Components/Button.js
@@ -4,12 +4,14 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from './Icon';
+import IconGroup from './IconGroup';
 
 class Button extends Component {
   
   render() {
 
-		let Tag = 'button';
+    let Tag = 'button';
+    let children = this.props.children;
 
 		// Uses the Link component if the button has a path property
 		if(this.props.path && !this.props.link){
@@ -20,24 +22,14 @@ class Button extends Component {
 			Tag = 'a';
 		}
 
-		let buttonText = this.props.children.trim().split(' ');
-
-		// Attaches icons to the first/last word of the text so that they do not wrap independently.
-		if(this.props.iconBefore || this.props.iconAfter){
-			if(this.props.iconBefore){
-				const iconBefore = (
-					<Icon style={this.props.iconStyle} icon={this.props.iconBefore} />
-				);
-				buttonText[0] = '<span class="text--no-break"><i class="icon--before ' + this.props.iconBefore + '" aria-hidden="true"></i>' + buttonText[0] + '</span>';
-			}
-			if(this.props.iconAfter){
-				const iconAfter = (
-					<Icon style={this.props.iconStyle} icon={this.props.iconAfter} />
-				)
-				buttonText[buttonText.length - 1] = '<span class="text--no-break">' + buttonText[buttonText.length - 1]  + iconAfter + '</span>';
-			}
-		}
-
+    if (this.props.iconBefore || this.props.iconAfter) {
+      children = (
+        <IconGroup iconBefore={this.props.iconBefore} iconAfter={this.props.iconAfter} iconStyle={this.props.iconStyle}>
+          {children}
+        </IconGroup>
+      );
+    }
+		
 		let btnClasses = classNames({
 			'btn': true,
 			'btn--primary': this.props.type === 'primary',
@@ -53,7 +45,7 @@ class Button extends Component {
 		}
 
     return (
-      <Tag {...elementProps} className={btnClasses} onClick={this.props.onClick}>{buttonText}</Tag>
+      <Tag {...elementProps} className={btnClasses} onClick={this.props.onClick}>{children}</Tag>
     );
   }
 

--- a/sassquatch-react/client/app/Components/Icon.js
+++ b/sassquatch-react/client/app/Components/Icon.js
@@ -16,7 +16,7 @@ class Icon extends Component {
 
 Icon.propTypes = {
 	iconStyle: PropTypes.oneOf(['light', 'regular', 'solid']),
-	icon: PropTypes.string,
+	name: PropTypes.string.isRequired,
 };
 
 export default Icon;

--- a/sassquatch-react/client/app/Components/IconGroup.js
+++ b/sassquatch-react/client/app/Components/IconGroup.js
@@ -1,0 +1,74 @@
+import React, { Fragment } from 'react';
+import Icon from './Icon';
+import Text from './Text';
+import PropTypes from 'prop-types';
+
+export default function IconGroup(props) {
+  const {
+    children,
+    iconBefore,
+    iconAfter,
+    iconStyle,
+    noBreak
+  } = props;
+
+  let element = null;
+  let beforeElement = Boolean(iconBefore) && <Icon name={iconBefore} style={iconStyle} before />;
+  let afterElement = Boolean(iconAfter) && <Icon name={iconAfter} style={iconStyle} after />;
+  let mainElement = children;
+
+  // If chilren is a plain string and noBreak is enabled
+  if (typeof children === 'string' && noBreak) {
+    const firstIndex = children.indexOf(' ');
+    const lastIndex = children.lastIndexOf(' ');
+    const isTwoWordsOrLess = firstIndex === lastIndex;
+
+    // Two words or less with both before + end icons is a special case,
+    // can use noBreak as the main element.
+    if (isTwoWordsOrLess && iconBefore && iconAfter) {
+      
+      return (
+        <Text noBreak>
+          {beforeElement}
+          {children}
+          {afterElement}
+        </Text>
+      );
+    } else {
+      // More then two words with both icons, noBreak the first and last elements
+      let start = children.slice(0, firstIndex + 1);
+      let end = children.slice(lastIndex);
+
+      if (beforeElement) {
+        beforeElement = <Text noBreak>{beforeElement}{start}</Text>;
+      } else {
+        beforeElement = start;
+      }
+
+      if (afterElement) {
+        afterElement = <Text noBreak>{end}{afterElement}</Text>;
+      } else {
+        afterElement = end;
+      }
+
+      // Middle part of string
+      mainElement = children.slice(firstIndex + 1, lastIndex); 
+    }
+  }
+
+  return (
+    <Fragment>
+      {beforeElement}
+      {mainElement}
+      {afterElement}
+    </Fragment>
+  );
+}
+
+IconGroup.defaultProps = {
+  noBreak: true
+}
+
+IconGroup.propTypes = {
+  noBreak: PropTypes.bool
+}

--- a/sassquatch-react/client/app/Components/Text.js
+++ b/sassquatch-react/client/app/Components/Text.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+export default function Text(props) {
+  const {
+    noBreak,
+    children,
+    ...otherProps
+  } = props;
+  
+  const className = classNames({
+    'text--no-break': props.noBreak
+  }, props.className);
+
+  return <span {...otherProps} className={className}>{children}</span>;
+}
+
+Text.propTypes = {
+  noBreak: PropTypes.bool
+};


### PR DESCRIPTION
This PR includes the logic we talked about for handling the no break with icons and basic string children, I extract it into its own `IconGroup` component since it could be useful in other areas outside of just buttons.

The `IconGroup` will fallback to just before + end icons if children is not a string.

