### PR TITLE
Add window.showPopup function

### DIFF
--- a/packages/react/assets/scripts/popups.js
+++ b/packages/react/assets/scripts/popups.js
@@ -2,6 +2,27 @@
 
   var prevLocation;
 
+  // show a simple popup similar to an alert
+  window.showPopup = function(message, title){
+    prevLocation = $(document.activeElement);
+    $('body').addClass('popup--open');
+    $('body').append('<div class="popup__overlay"></div>');
+    var newPopup = $('<div class="popup"></div>');
+    newPopup.append($("<button class='popup__close'>").append(
+    $('<i class="far fa-times" aria-hidden="true"></i><span class="webaim-hidden">Close popup</span>')
+    ));
+    newPopup.append($("<h3>").text(title));
+    newPopup.append($("<p>").text(message));
+
+    // add temporary so that the popup gets removed when it closes
+    newPopup.addClass('popup__temporary open');
+
+    $('body').append(newPopup);
+    newPopup.fadeIn('fast');
+    $('.popup__overlay').fadeIn('fast');
+    newPopup.find('.popup__close').focus();
+  };
+
   // Manages opening of popup modals
   $('*[data-popup]').click(function(){
     prevLocation = $(this);
@@ -18,6 +39,7 @@
     $('body').removeClass('popup--open');
     $('.popup__overlay').remove();
     $('.popup').hide();
+    $('.popup.popup__temporary').remove();
     prevLocation.focus();
   });
 
@@ -27,6 +49,7 @@
         var target = $('.popup[style="display: block;"]');
         $('.popup__overlay').remove();
         $('.popup').hide();
+        $('.popup.popup__temporary').remove();
         $('.popup.open').removeClass('open');
         prevLocation.focus();
       }

--- a/static/templates/index.twig
+++ b/static/templates/index.twig
@@ -284,6 +284,7 @@
 			<section id="sassquatch-popups">
 				<h2 class="jumplink__target">Popups</h2>
 				<button class="button" data-popup="popup-1">Example Popup</button>
+				<button class="button" onclick='showPopup(new Date().toString(), "Current date and time");'>Dynamic Popup</button>
 				<div id="popup-1" class="popup">
 					<button class="popup__close"><i class="far fa-times" aria-hidden="true"></i><span class="webaim-hidden">Close popup</span></button>
 					<h3>Popup</h3>


### PR DESCRIPTION
This adds a simple function to the window namespace:
`showPopup(message, title)`
It can be used to easily show error messages or other blocking modal issues. It should follow all the functionality of the currently templated popups.