### PR TITLE
Add CSS-driven form switches

### DIFF
--- a/packages/theme/assets/styles/components/_forms.scss
+++ b/packages/theme/assets/styles/components/_forms.scss
@@ -86,6 +86,98 @@ form{
       }
     }
   }
+  &__switch{
+
+    /* The switch - the box around the slider */
+    position: relative;
+    display: inline-block;
+    width: 80px;
+    &.medium{
+      width: 120px;
+    }
+    &.large{
+      width: 160px;
+    }
+    height: 34px;
+    vertical-align: bottom;
+
+    /* Hide default HTML checkbox */
+    input {
+      @include set-webaim-hidden();
+    }
+
+    /* The slider */
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: $color-lt;
+      transition: .4s;
+      border-radius: 34px;
+      border: 1px solid $color-med;
+      box-shadow: inset 0 0 0 1px $color-lt;
+    }
+
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 26px;
+      width: 26px;
+      left: 2px;
+      bottom: 2px;
+      background-color: $color-brand-2;
+      border: 1px solid $color-med;
+      transition: .4s;
+      border-radius: 50%;
+    }
+
+    input:checked + .slider {
+      background-color: $color-brand-1;
+    }
+
+    input:focus + .slider {
+      box-shadow: inset 0 0 0 1px $color-lt, 0 0 3px 1px $color-brand-1;
+    }
+
+    input + .slider::after{
+      content: "Off";
+      text-align: right;
+      display: block;
+      padding: 0 10px;
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 32px;
+    }
+    input + .slider[data-off]::after{
+      content: attr(data-off);
+    }
+
+    input:checked + .slider::after{
+      content: "On";
+      text-align: left;
+      color: $color-lt;
+    }
+    input:checked + .slider[data-on]::after{
+      content: attr(data-on);
+    }
+
+    input:checked + .slider:before {
+      transform: translateX(46px);
+    }
+    &.medium{
+      input:checked + .slider:before {
+        transform: translateX(86px);
+      }
+    }
+    &.large{
+      input:checked + .slider:before {
+        transform: translateX(126px);
+      }
+    }
+  }
 }
 
 fieldset{

--- a/static/templates/components/forms.twig
+++ b/static/templates/components/forms.twig
@@ -47,5 +47,20 @@
 				<span class="form__checkbox-label">Radio Button 3</span>
 			</label>
 		</fieldset>
+		<fieldset class="form__group">
+			<legend class="form__label">Switch Group</legend>
+			<label class="form__switch">
+				<input id="switch-1" type="checkbox" name="switches-1" value="switch-1">
+				<span class="slider"  ></span>
+			</label>
+			<label class="form__switch medium" >
+				<input id="switch-2" type="checkbox" name="switches-1" value="switch-2">
+				<span class="slider" data-on="Enabled" data-off="Disabled" ></span>
+			</label>
+			<label class="form__switch large">
+				<input id="switch-3" type="checkbox" name="switches-1" value="switch-3">
+				<span class="slider" data-off="Name Fallback" ></span>
+			</label>
+		</fieldset>
 	</form>
 </section>


### PR DESCRIPTION
A bit wordy and restrictive in style, these switches are commonly needed in place of simple check-boxes in designs.
I included 2 extra "sizes" of .medium and .large to accommodate longer names/labels. The width must be set absolutely and the slider's position when checked must be updated accordingly, so I can't easily make this dynamic without JS.
One cool feature is the ability to specify the on/off names in the markup using data-on and data-off. Read the examples to see.