### PR TITLE
Add some basic media query mixins and examples

### DIFF
--- a/packages/theme/assets/styles/config/mixins/_structure.scss
+++ b/packages/theme/assets/styles/config/mixins/_structure.scss
@@ -7,13 +7,13 @@
 }
 
 @mixin for-size($size) {
-  @media (max-width: $size - 1) {
+  @media (max-width: $size) {
     @content;
   }
 }
 
 @mixin larger-than($size) {
-  @media (min-width: $size) {
+  @media (min-width: $size + 1) {
     @content;
   }
 }

--- a/packages/theme/assets/styles/config/mixins/_structure.scss
+++ b/packages/theme/assets/styles/config/mixins/_structure.scss
@@ -5,3 +5,15 @@
     display: table;
   }
 }
+
+@mixin for-size($size) {
+  @media (max-width: $size - 1) {
+    @content;
+  }
+}
+
+@mixin larger-than($size) {
+  @media (min-width: $size) {
+    @content;
+  }
+}

--- a/packages/theme/assets/styles/demo.scss
+++ b/packages/theme/assets/styles/demo.scss
@@ -99,3 +99,27 @@ a{
 		}
 	}
 }
+
+pre{
+	font-family: monospace;
+	background: $color-lt;
+	color: $color-brand-2;
+	@include set-type(11);
+	padding: $gutter-width;
+	margin-bottom: $gutter-width;
+	border: 1px solid $color-brand-1-lt;
+	line-height: 1.2;
+}
+
+.thing{
+	color: red;
+	@include for-size($tablet) {
+		color: blue;
+	}
+	@include for-size($mobile) {
+		color: green;
+	}
+	@include larger-than($tablet){
+		background-color: moccasin;
+	}
+}

--- a/static/templates/components/mixins.twig
+++ b/static/templates/components/mixins.twig
@@ -1,0 +1,21 @@
+<section id="sassquatch-mixins">
+    <h2 class="jumplink__target">Mixins</h2>
+    <pre>
+.thing{
+	color: red;
+	@include for-size($tablet) {
+		color: blue;
+	}
+	@include for-size($mobile) {
+		color: green;
+	}
+	@include larger-than($tablet){
+		background-color: moccasin;
+	}
+}
+    </pre>
+    <div class="thing card">
+        This text changes color based on screen size.
+    </div>
+
+</section>

--- a/static/templates/index.twig
+++ b/static/templates/index.twig
@@ -32,6 +32,8 @@
 			{% include "/components/alerts.twig" %}
 			<hr>
 			{% include "/components/tooltips.twig" %}
+			<hr>
+			{% include "/components/mixins.twig" %}
       <hr>
       {% include "/components/tabs.twig" %}
 		</div>


### PR DESCRIPTION
Adds two simple helper mixins to help remember when to - 1 or + 1.

- `for-size($size)` makes a media query that applies up to and including the size specified
- `larger-than($size)` makes a media query that applies to anything larger than **but not including** the size specified

Why? I kept forgetting when to add + 1 or - 1 to the min-width and max-width media queries so it would be nice to have a standard, easy to remember function handle it for me.